### PR TITLE
Correct Cypress tests

### DIFF
--- a/cypress/integration/block-basics.js
+++ b/cypress/integration/block-basics.js
@@ -5,16 +5,17 @@ describe('Blocks Tests', () => {
   afterEach(tearDownAfterEach);
 
   it('Add Block: Empty', () => {
-    // Change page title
-    cy.get('.documentFirstHeading > .public-DraftStyleDefault-block')
-      .clear()
-      .type('My Add-on Page')
-      .get('.documentFirstHeading span[data-text]')
-      .contains('My Add-on Page');
+    // without this the clear command below does nothing sometimes
+    cy.wait(500);
 
-    cy.get('.documentFirstHeading > .public-DraftStyleDefault-block').type(
-      '{enter}',
-    );
+    // Change page title
+    cy.get('[contenteditable=true]').first().clear();
+
+    cy.get('[contenteditable=true]').first().type('My Add-on Page');
+
+    cy.get('.documentFirstHeading').contains('My Add-on Page');
+
+    cy.get('[contenteditable=true]').first().type('{enter}');
 
     // Add block
     cy.get('.ui.basic.icon.button.block-add-button').first().click();

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -44,7 +44,7 @@ export const setupBeforeEach = () => {
   cy.waitForResourceToLoad('@types');
   cy.waitForResourceToLoad('my-page');
   cy.navigate('/cypress/my-page/edit');
-  cy.get(`.block.title [data-contents]`);
+  cy.get(`.block.title h1`);
 };
 
 export const tearDownAfterEach = () => {


### PR DESCRIPTION
to work with the new Slate-based Title blocks